### PR TITLE
Add GitHub Actions workflow for linting on pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: Lint
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run lint


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate linting for pull requests targeting the `main` branch. 

### CI/CD Enhancements:
* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R1-R18): Added a GitHub Actions workflow named "Lint" that triggers on pull requests to the `main` branch. It sets up a Node.js environment (version 22), installs dependencies using `npm ci`, and runs the linting process with `npm run lint`.